### PR TITLE
Remove build task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,19 +2,6 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"label": "CMSIS Build",
-			"type": "cmsis-csolution.build",
-			"solution": "${command:cmsis-csolution.getSolutionPath}",
-			"project": "${command:cmsis-csolution.getProjectPath}",
-			"buildType": "${command:cmsis-csolution.getBuildType}",
-			"targetType": "${command:cmsis-csolution.getTargetType}",
-			"problemMatcher": [],
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		},
-		{
 			"label": "Flash Device",
 			"type": "embedded-debug.flash",
 			"program": "${command:embedded-debug.getApplicationFile}",


### PR DESCRIPTION
* The `getProjectPath` and `getBuildType` commands are being removed from the [csolution extension](https://github.com/Arm-Debug/vscode-cmsis-csolution)
* The extension's build buttons don't require this build task anymore
